### PR TITLE
Listas de membresías con datos de prueba

### DIFF
--- a/frontend/src/App2.js
+++ b/frontend/src/App2.js
@@ -15,6 +15,7 @@ import { ProvidersPage } from './files/ShowProvidersPage.jsx';
 import { MembershipsPage } from './files/ShowMemberships.jsx';
 import { ActiveClientsPage } from './files/entrenador/ShowActiveClients.jsx';
 import { MembresiasPage } from './files/cliente/MembresiasPage.jsx';
+import { MisMembresiasPage } from './files/cliente/MisMembresiasPage.jsx';
 
 document.documentElement.lang = "es"; //Establece el idioma de la página en español
 
@@ -52,6 +53,7 @@ function App() {
         {/* AQUÍ DEBEN IR LAS RUTAS DEL CLIENTE */}
         <Route element={<ProtectedRoutes fallbackPath="/login" ranges={['Cliente']} />}>
           <Route path="/membresias" element={<MembresiasPage />} />
+          <Route path="/mis_membresias" element={<MisMembresiasPage />} />
         </Route>
       </Routes>
     </>

--- a/frontend/src/App2.js
+++ b/frontend/src/App2.js
@@ -14,6 +14,7 @@ import { TrainersPage } from './files/ShowTrainersPage.jsx';
 import { ProvidersPage } from './files/ShowProvidersPage.jsx';
 import { MembershipsPage } from './files/ShowMemberships.jsx';
 import { ActiveClientsPage } from './files/entrenador/ShowActiveClients.jsx';
+import { MembresiasPage } from './files/cliente/MembresiasPage.jsx';
 
 document.documentElement.lang = "es"; //Establece el idioma de la página en español
 
@@ -40,11 +41,17 @@ function App() {
           <Route path="/admin/administradores" element={<AdminsPage />} />
           <Route path="/admin/proveedores" element={<ProvidersPage />} />
           <Route path="/admin/membresias" element={<MembershipsPage />} />
+          <Route path="/admin/membresias_mock" element={<MembresiasPage />} />
         </Route>
 
         {/* AQUÍ DEBEN IR LAS RUTAS DEL ENTRENADOR */}
         <Route element={<ProtectedRoutes fallbackPath="/login" ranges={['Entrenador']} />}>
           <Route path="/entrenador/clientes_activos" element={<ActiveClientsPage />} />
+        </Route>
+
+        {/* AQUÍ DEBEN IR LAS RUTAS DEL CLIENTE */}
+        <Route element={<ProtectedRoutes fallbackPath="/login" ranges={['Cliente']} />}>
+          <Route path="/membresias" element={<MembresiasPage />} />
         </Route>
       </Routes>
     </>

--- a/frontend/src/files/cliente/MembresiasPage.jsx
+++ b/frontend/src/files/cliente/MembresiasPage.jsx
@@ -1,0 +1,157 @@
+import { Card, Placeholder } from 'react-bootstrap';
+import styles from './MembresiasPage.module.css';
+import { useEffect, useState } from 'react';
+import { getMembresiasDisplay } from '../../services/general';
+import { useUser } from '../../contexts/UserContext';
+
+const cardStyles = {
+  backgroundColor: '#3A33BB',
+  borderRadius: '20px',
+  position: 'relative',
+  paddingTop: '35px',
+  width: '21rem',
+};
+
+export function MembresiasPage() {
+  const [dataState, setDataState] = useState({
+    loading: true,
+    error: null,
+    data: [],
+  });
+
+  const { isLogged, auth } = useUser();
+
+
+  useEffect(() => {
+    getMembresiasDisplay('token')
+      .then((data) => {
+        setDataState({ loading: false, error: null, data });
+      })
+      .catch((error) => {
+        setDataState({ loading: false, error: error.message, data: [] });
+      });
+  }, []);
+
+  let cards;
+
+  if (dataState.loading) {
+    cards = Array.from({ length: 3 }, (_, index) => (
+      <PlaceHolderCard key={index} />
+    ));
+  } else if (dataState.error) {
+    cards = (
+      <Card className={`${styles.card}`} style={cardStyles}>
+        <Card.Body>
+        <div
+          className={`${styles.titleContainer} ${styles.absoluteCenterTitle}`}
+        >
+          <h1 className={`${styles.title}`}>Error</h1>
+        </div>
+          <p>{dataState.error}</p>
+        </Card.Body>
+      </Card>
+    );
+  } else if (dataState.data.length === 0) {
+    cards = (
+      <Card className={`${styles.card}`} style={cardStyles}>
+        <Card.Body>
+          <div className={`${styles.titleContainer}`}>
+            <h1 className={`${styles.title}`}>No hay membresías disponibles</h1>
+          </div>
+        </Card.Body>
+      </Card>
+    );
+  } else {
+    cards = dataState.data.map((item, index) => (
+      <MemberCard key={index} {...item} />
+    ));
+  }
+
+  return (
+    <>
+      <div className={`${styles.titleSection}`}>
+        <div className={`${styles.titleContainer}`}>
+          <h1 className={`${styles.title}`}>Membresías Disponibles</h1>
+        </div>
+      </div>
+      <div className={`${styles.cardSection}`}>{cards}</div>
+      {(isLogged && auth.rango==='Cliente') && (<div className={`${styles.titleSection}`}>
+        <button className={`${styles.squareButton}`}>Mis Membresías</button>
+      </div>)}
+    </>
+  );
+}
+
+/**
+ * @param {{
+ *   title: string,
+ *   price: number,
+ *   features: string[]
+ * }} props
+ * @returns 
+ */
+function MemberCard({
+  title = 'Estándar',
+  price = 50000,
+  features = [
+    'Membresía estándar con acceso a entrenamientos',
+    'Máximo 40 Miembros',
+    'Duración de 1 mes',
+    'Descuento del 20% en todas las actividades',
+  ],
+}) {
+  return (
+    <Card className={`${styles.card}`} style={cardStyles}>
+      <Card.Body>
+        <div
+          className={`${styles.titleContainer} ${styles.absoluteCenterTitle}`}
+        >
+          <h1 className={`${styles.title}`}>{title}</h1>
+        </div>
+        <ul className={`${styles.featureList}`}>
+          {features.map((feature, index) => (
+            <li key={index}>
+              {feature}
+            </li>
+          ))}
+        </ul>
+        <div className={`${styles.footer}`}>
+          <span>Desde:</span>
+          <button className={`btn btn-primary mt-8 ${styles.btn}`}>
+            {`${new Intl.NumberFormat('es-CO', {
+              style: 'currency',
+              currency: 'COP',
+              minimumFractionDigits: 0,
+              maximumFractionDigits: 0,
+            }).format(price)} COP`}
+          </button>
+        </div>
+      </Card.Body>
+    </Card>
+  );
+}
+
+function PlaceHolderCard(){
+  return (
+    <Card className={`${styles.card}`} style={cardStyles}>
+      <Card.Body>
+          <Placeholder as={Card.Title} animation="glow">
+            <Placeholder xs={6} />
+          </Placeholder>
+          <Placeholder as={Card.Text} animation="glow">
+            <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
+            <Placeholder xs={6} /> <Placeholder xs={8} />
+          </Placeholder>
+          <Placeholder as={Card.Text} animation="glow">
+            <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
+            <Placeholder xs={6} /> <Placeholder xs={8} />
+          </Placeholder>
+          <Placeholder as={Card.Text} animation="glow">
+            <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
+            <Placeholder xs={6} /> <Placeholder xs={8} />
+          </Placeholder>
+          <Placeholder.Button variant="primary" xs={6} />
+        </Card.Body>
+    </Card>
+  );
+}

--- a/frontend/src/files/cliente/MembresiasPage.module.css
+++ b/frontend/src/files/cliente/MembresiasPage.module.css
@@ -1,7 +1,7 @@
 .titleSection {
   display: flex;
   justify-content: center;
-  padding-block: 20px;
+  padding-bottom: 20px;
 }
 
 .titleContainer {
@@ -28,6 +28,7 @@
   gap: 20px;
   padding-block: 20px;
   padding-top: 30px;
+  margin-bottom: 25px;
 
   /* width: 100%; */
   max-width: calc(21rem * 2 + 80px);

--- a/frontend/src/files/cliente/MembresiasPage.module.css
+++ b/frontend/src/files/cliente/MembresiasPage.module.css
@@ -1,0 +1,133 @@
+.titleSection {
+  display: flex;
+  justify-content: center;
+  padding-block: 20px;
+}
+
+.titleContainer {
+  background-color: #181640;
+  padding: 3px 25px;
+  border-radius: 18px;
+  /* margin-top: -20px; */
+}
+
+.title {
+  font-family: 'Hyperwave', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 3.5rem;
+  color: white;
+  
+  margin: 0;
+  margin-bottom: 2px;
+}
+
+/*----------------------------CARD SECTION------------------------------*/
+
+.cardSection {
+  display: flex;
+  justify-content: start;
+  gap: 20px;
+  padding-block: 20px;
+  padding-top: 30px;
+
+  /* width: 100%; */
+  max-width: calc(21rem * 2 + 80px);
+  margin-inline: auto;
+  
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+
+  /* Scrollbar */
+  scrollbar-width: thin;
+  scrollbar-color: #3A33BB #181640;
+  scrollbar-gutter: auto;
+}
+
+.cardSection > div {
+  flex: 0 0 auto;
+
+  scroll-snap-align: start;
+}
+
+.card {
+  background-color: #3A33BB;
+
+  border-radius: 20px;
+  position: relative;
+
+  padding-top: 35px;
+
+  font-family: 'Montserrat';
+}
+
+.absoluteCenterTitle {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  padding: 0 45px;
+}
+
+.absoluteCenterTitle .title {
+  font-size: 2.5rem;
+}
+
+ul.featureList {
+  list-style-type: none;
+}
+
+ul.featureList li {
+  margin-bottom: 25px;
+  color: black;
+
+  padding-left: 10px;
+  position: relative;
+}
+
+ul.featureList li::before {
+  content: "✓"; /* Bullet personalizado */
+  position: absolute;
+  left: 0; /* Coloca el bullet al principio de la lista */
+  top: 50%; /* Centra el bullet verticalmente */
+  transform: translateY(-50%) translateX(-110%); /* Ajusta la posición vertical al centro exacto */
+
+  color: white;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.card .footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  margin-top: 30px;
+}
+
+.card .footer span {
+  color: white;
+  font-size: .8rem;
+  font-weight: lighter;
+}
+
+.card .footer .btn {
+  font-weight: normal !important;
+}
+
+/*-------------------------------------------------------------------------*/
+
+.squareButton {
+  padding: 15px 30px;
+  background-color: #3A33BB;
+  color: white;
+
+  border: none;
+  border-radius: 10px;
+
+  font-family: 'Montserrat';
+  font-weight: normal;
+}
+
+.squareButton:hover {
+  background-color: #262367;
+}

--- a/frontend/src/files/cliente/MisMembresiasPage.jsx
+++ b/frontend/src/files/cliente/MisMembresiasPage.jsx
@@ -14,7 +14,7 @@ const cardStyles = {
   width: '21rem',
 };
 
-export function MembresiasPage() {
+export function MisMembresiasPage() {
   const [dataState, setDataState] = useState({
     loading: true,
     error: null,
@@ -22,7 +22,6 @@ export function MembresiasPage() {
   });
 
   const { isLogged, auth } = useUser();
-
 
   useEffect(() => {
     getMembresiasDisplay('token')
@@ -44,11 +43,11 @@ export function MembresiasPage() {
     cards = (
       <Card className={`${styles.card}`} style={cardStyles}>
         <Card.Body>
-        <div
-          className={`${styles.titleContainer} ${styles.absoluteCenterTitle}`}
-        >
-          <h1 className={`${styles.title}`}>Error</h1>
-        </div>
+          <div
+            className={`${styles.titleContainer} ${styles.absoluteCenterTitle}`}
+          >
+            <h1 className={`${styles.title}`}>Error</h1>
+          </div>
           <p>{dataState.error}</p>
         </Card.Body>
       </Card>
@@ -77,18 +76,14 @@ export function MembresiasPage() {
         }}>
           <h1 className="logo">GYMCONTROL</h1>
         </Link>
-
         <MyNavbar />
       </header>
       <div className={`${styles.titleSection}`}>
         <div className={`${styles.titleContainer}`}>
-          <h1 className={`${styles.title}`}>Membresías Disponibles</h1>
+          <h1 className={`${styles.title}`}>Mis Membresías</h1>
         </div>
       </div>
       <div className={`${styles.cardSection}`}>{cards}</div>
-      {(isLogged && auth.rango==='Cliente') && (<div className={`${styles.titleSection}`}>
-        <Link to='/mis_membresias' className={`${styles.squareButton}`}>Mis Membresías</Link>
-      </div>)}
     </>
   );
 }
@@ -99,7 +94,7 @@ export function MembresiasPage() {
  *   price: number,
  *   features: string[]
  * }} props
- * @returns 
+ * @returns
  */
 function MemberCard({
   title = 'Estándar',
@@ -121,9 +116,7 @@ function MemberCard({
         </div>
         <ul className={`${styles.featureList}`}>
           {features.map((feature, index) => (
-            <li key={index}>
-              {feature}
-            </li>
+            <li key={index}>{feature}</li>
           ))}
         </ul>
         <div className={`${styles.footer}`}>
@@ -142,27 +135,27 @@ function MemberCard({
   );
 }
 
-function PlaceHolderCard(){
+function PlaceHolderCard() {
   return (
     <Card className={`${styles.card}`} style={cardStyles}>
       <Card.Body>
-          <Placeholder as={Card.Title} animation="glow">
-            <Placeholder xs={6} />
-          </Placeholder>
-          <Placeholder as={Card.Text} animation="glow">
-            <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
-            <Placeholder xs={6} /> <Placeholder xs={8} />
-          </Placeholder>
-          <Placeholder as={Card.Text} animation="glow">
-            <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
-            <Placeholder xs={6} /> <Placeholder xs={8} />
-          </Placeholder>
-          <Placeholder as={Card.Text} animation="glow">
-            <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
-            <Placeholder xs={6} /> <Placeholder xs={8} />
-          </Placeholder>
-          <Placeholder.Button variant="primary" xs={6} />
-        </Card.Body>
+        <Placeholder as={Card.Title} animation="glow">
+          <Placeholder xs={6} />
+        </Placeholder>
+        <Placeholder as={Card.Text} animation="glow">
+          <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
+          <Placeholder xs={6} /> <Placeholder xs={8} />
+        </Placeholder>
+        <Placeholder as={Card.Text} animation="glow">
+          <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
+          <Placeholder xs={6} /> <Placeholder xs={8} />
+        </Placeholder>
+        <Placeholder as={Card.Text} animation="glow">
+          <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
+          <Placeholder xs={6} /> <Placeholder xs={8} />
+        </Placeholder>
+        <Placeholder.Button variant="primary" xs={6} />
+      </Card.Body>
     </Card>
   );
 }

--- a/frontend/src/services/general.js
+++ b/frontend/src/services/general.js
@@ -1,0 +1,80 @@
+import axios from "axios";
+
+/**
+ * @typedef {Object} MembresiaDysplay
+ * @property {string} id
+ * @property {string} title
+ * @property {number} price
+ * @property {string[]} features
+ */
+
+/**
+ * @type {MembresiaDysplay[]}
+ */
+const mockMembresias = [
+  {
+    id: '1',
+    title: 'Estándar',
+    price: 50000,
+    features: [
+      'Membresía estándar con acceso a entrenamientos',
+      'Máximo 40 Miembros',
+      'Duración de 1 mes',
+      'Descuento del 20% en todas las actividades',
+    ],
+  },
+  {
+    id: '2',
+    title: 'Premium',
+    price: 100000,
+    features: [
+      'Membresía premium con acceso a entrenamientos',
+      'Máximo 60 Miembros',
+      'Duración de 1 mes',
+      'Descuento del 30% en todas las actividades',
+    ],
+  },
+  {
+    id: '3',
+    title: 'VIP',
+    price: 150000,
+    features: [
+      'Membresía VIP con acceso a entrenamientos',
+      'Máximo 80 Miembros',
+      'Duración de 1 mes',
+      'Descuento del 40% en todas las actividades',
+    ],
+  },
+];
+
+/**
+ * Retorna las membresias disponibles
+ * @param {string} token
+ * @returns {Promise<MembresiaDysplay[]>}
+ */
+export function getMembresiasDisplay(token) {
+  // return axios
+  //   .get('http://localhost:8888/admin/membresias', {
+  //     headers: {
+  //       'Content-Type': 'application/json',
+  //       Authorization: `Bearer ${token}`,
+  //     },
+  //   })
+  //   .then(({ data, status }) => {
+  //     if (status === 200) {
+  //       return (data.resultado ?? []).map((membresia) => ({
+  //           id: membresia.id,
+  //           title: membresia.nombre,
+  //           price: membresia.precio,
+  //           features: membresia.caracteristicas,
+  //         }));
+  //     } else {
+  //       throw new Error('Error al cargar los datos');
+  //     }
+  //   });
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(mockMembresias);
+    }, 1000);
+  });
+}


### PR DESCRIPTION
Ahora se pueden ver las membresías como se preveía en el figma. Sin embargo solo con datos de prueba.

Se Puede acceder como usuario cliente a través del Navbar (enlace membresías), o por las rutas `/membresias` y `/mis_membresias`.
<hr></hr>

@sebaslazar Podría pedir que el endpoint que retorna la lista de membresías retorne algunos datos como en el figma?
que contenga, por ejemplo, nombre, precio, id, y algunos datos más para mostrar como en el figma (como la descripción, descuento, maxMiembros, etc)

Por otro lado el endpoint para ver la lista de membresías no debería ser o bien público o bien para clientes? Es que el endpoint es, si no estoy mal, /admin/membresias.

En todo caso de momento se puede ver como va quedando esa vista con los datos de prueba.